### PR TITLE
Fixed semester and position show page

### DIFF
--- a/app/views/positions/show.html.erb
+++ b/app/views/positions/show.html.erb
@@ -8,7 +8,7 @@
 <p>
   <strong>Members:</strong>
   <% @position.members.each do |b| %>
-    <li><%= b.firstName %> <%= b.lastName %></li>
+    <li><%= b.first_name %> <%= b.last_name %></li>
   <% end %>
 </p>
 

--- a/app/views/semesters/show.html.erb
+++ b/app/views/semesters/show.html.erb
@@ -8,7 +8,7 @@
 <p>
   <strong>Members:</strong>
   <% @semester.members.each do |b| %>
-    <li><%= b.firstName %> <%= b.lastName %></li>
+    <li><%= b.first_name %> <%= b.last_name %></li>
   <% end %>
 </p>
 


### PR DESCRIPTION
Due to attribute change in the member model, Semester and Position show page was broken. Fixed this problem by changing firstName and lastName to first_name and last_name.